### PR TITLE
ci: マイナーバージョンの更新も自動マージに変更する

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## 背景

パッチバージョンの更新であれば、自動マージされるように変更しました。ただ、マイナーバージョンも頻繁に更新されるため、結果更新頻度はあまり変わらず、レビューの負荷軽減に繋がりませんでした。

## 概要

レビューの負荷を軽減するため、マイナーバージョンの更新も自動マージされるように修正しましたので、ご確認よろしくお願いいたします。