### PR TITLE
ライブラリのバージョンを固定

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "official",
       "version": "0.0.1",
       "dependencies": {
-        "@fontsource/zen-kaku-gothic-new": "^5.2.7",
-        "@tailwindcss/vite": "^4.2.0",
-        "astro": "^5.17.3",
-        "tailwindcss": "^4.2.0"
+        "@fontsource/zen-kaku-gothic-new": "5.2.7",
+        "@tailwindcss/vite": "4.2.0",
+        "astro": "5.17.3",
+        "tailwindcss": "4.2.0"
       },
       "engines": {
         "node": "24.13.0",
@@ -5220,6 +5220,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@fontsource/zen-kaku-gothic-new": "^5.2.7",
-    "@tailwindcss/vite": "^4.2.0",
-    "astro": "^5.17.3",
-    "tailwindcss": "^4.2.0"
+    "@fontsource/zen-kaku-gothic-new": "5.2.7",
+    "@tailwindcss/vite": "4.2.0",
+    "astro": "5.17.3",
+    "tailwindcss": "4.2.0"
   }
 }


### PR DESCRIPTION
## 概要

- dependabotのセキュリティアップデートによって、ライブラリは自動で更新されていくため、 `package.json` 上はバージョン指定を固定としました