### PR TITLE
ライセンスの追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright 2025 xuxyu ... PUNPOPUNPO Technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@
   - `.node-version` ファイルはCloudflareがNode.jsのバージョンを把握するために残している
 
 ```bash
-mise trust
-mise install
-npm install
-npm run dev
+$ mise trust
+$ mise install
+$ npm install
+$ npm run dev
 ```
+
+## License
+
+- ソースコード: [MIT License](./LICENSE)
+- コンテンツ(テキスト、画像、その他素材): [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) © 2025 xuxyu ... PUNPOPUNPO Technologies


### PR DESCRIPTION
## 概要

- 基本的にチーム内からのPRしか来ないとは思うが、public repositoryではあるため、ライセンスを設定
- ソースコードにはMIT、コンテンツにはCC BY-NC 4.0を付与
- 開始年は本リポジトリが作成された2025年に設定

## ソースコード(MIT)

- コードの再利用・改変・再配布を広く許可しつつ、著作権表示の保持のみを条件とする
- ソフトウェアライセンスとして最も広く普及しており、コントリビューターにとって馴染みがある
- オフィシャルサイトのコードは他プロジェクトへの転用可能性が低く、過度な制限をかける必要がない
- ライセンスの条文の取得先: https://opensource.org/license/mit

## コンテンツ(CC BY-NC 4.0)

- 帰属表示(リンク)があれば情報の共有・紹介を自由に認める
- 非商用条件(NC)により、広告・プロモーション目的での無断転用を禁止する
- CC ライセンス共通の条項により、チームを名乗るなどの虚偽の帰属表示を禁止する
