### PR TITLE
biome.jsonスキーマ更新ワークフローのトリガーをpushに変更

### DIFF
--- a/.github/workflows/update-biome-schema.yml
+++ b/.github/workflows/update-biome-schema.yml
@@ -1,8 +1,10 @@
 name: Update biome.json schema
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
 
 permissions:
   contents: write
@@ -10,22 +12,12 @@ permissions:
 jobs:
   update-biome-schema:
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.repository == 'uyupun/tmp-official'
+    if: github.repository == 'uyupun/tmp-official'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: main
-
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
 
       - name: Update biome.json schema version
-        if: contains(steps.metadata.outputs.dependency-names, '@biomejs/biome')
         run: |
           VERSION=$(node -p "require('./package.json').devDependencies['@biomejs/biome']")
           sed -i "s|https://biomejs.dev/schemas/[^/]*/schema.json|https://biomejs.dev/schemas/${VERSION}/schema.json|" biome.json


### PR DESCRIPTION
## 背景

- `dependabot-auto-merge.yml` が `GITHUB_TOKEN` を使って PR をマージしているため、その際に発生する `pull_request: closed` イベントは GitHub の仕様上、他のワークフローに伝わらない
- そのため `update-biome-schema.yml` が一度も正常に動作しておらず、`biome.json` のスキーマが古いままになっていた

## 変更内容
- トリガーを `pull_request: closed` から `push` (main, paths: `package.json`) に変更
- `GITHUB_TOKEN` によるマージも main への push として検知されるため、この制限を回避できる
- 不要になった `dependabot/fetch-metadata` ステップと dependabot 関連の条件を削除
